### PR TITLE
Keep parity with CDN version of GOV.UK Frontend

### DIFF
--- a/assets/src/scss/__global.scss
+++ b/assets/src/scss/__global.scss
@@ -1,15 +1,3 @@
-// Opt into new organisations colours
-// https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-new-organisation-colours
-// Remove when updating to version 6
-$govuk-new-organisation-colours: true;
-
-// Opt into new typography scale
-// https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-new-typography-scale
-// Remove when updating to version 6
-$govuk-new-typography-scale: true;
-
-$govuk-global-styles: true;
-
 // See: https://frontend.design-system.service.gov.uk/sass-api-reference/
 // Import the base GOV.UK Frontend so we can make use of the utility helpers
 @import "govuk/base";

--- a/src/views/partials/cookie_consent_banner.njk
+++ b/src/views/partials/cookie_consent_banner.njk
@@ -1,16 +1,16 @@
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
 {% set html %}
-  <p>We use some essential cookies to make our services work.</p>
-  <p>We'd also like to use analytics cookies so we can understand how you use our services and to make improvements.</p>
+  <p class="govuk-body">We use some essential cookies to make our services work.</p>
+  <p class="govuk-body">We'd also like to use analytics cookies so we can understand how you use our services and to make improvements.</p>
 {% endset %}
 
 {% set acceptHtml %}
-  <p>You've accepted analytics cookies. You can <a class="govuk-link" href="{{ chsUrl }}/help/cookies">change your cookie settings</a> at any time.</p>
+  <p class="govuk-body">You've accepted analytics cookies. You can <a class="govuk-link" href="{{ chsUrl }}/help/cookies">change your cookie settings</a> at any time.</p>
 {% endset %}
 
 {% set rejectHtml %}
-  <p>You've rejected analytics cookies. You can <a class="govuk-link" href="{{ chsUrl }}/help/cookies">change your cookie settings</a> at any time.</p>
+  <p class="govuk-body">You've rejected analytics cookies. You can <a class="govuk-link" href="{{ chsUrl }}/help/cookies">change your cookie settings</a> at any time.</p>
 {% endset %}
 
 {{ govukCookieBanner({

--- a/src/views/partials/error.njk
+++ b/src/views/partials/error.njk
@@ -3,7 +3,7 @@
 {% block main_content %}
 
   <div class="error">
-    <p>{{ this_data.error_message }}</p>
+    <p class="govuk-body">{{ this_data.error_message }}</p>
   </div>
 
 {% endblock %}

--- a/src/views/router_views/company/create.njk
+++ b/src/views/router_views/company/create.njk
@@ -3,8 +3,8 @@
 {% block main_content %}
 
   <div class="generic-class-name">
-    <h3>Company Router: Create a company page</h3>
-    <p>{{ sampleKey }}</p>
+    <h1 class="govuk-heading-l">Company Router: Create a company page</h1>
+    <p class="govuk-body">{{ sampleKey }}</p>
 
     {% if dataSaved %}
       <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">

--- a/src/views/router_views/company/details.njk
+++ b/src/views/router_views/company/details.njk
@@ -3,8 +3,8 @@
 {% block main_content %}
 
   <div class="generic-class-name">
-    <h3>Company Router: Company details page</h3>
-    <p>{{ sampleKey }}</p>
+    <h1 class="govuk-heading-l">Company Router: Company details page</h1>
+    <p class="govuk-body">{{ sampleKey }}</p>
   </div>
 
 {% endblock %}

--- a/src/views/router_views/index/home.njk
+++ b/src/views/router_views/index/home.njk
@@ -3,8 +3,8 @@
 {% block main_content %}
 
   <div class="generic-class-name">
-    <h3>Index Router: Home page</h3>
-    <p>{{ sampleKey }}</p>
+    <h1 class="govuk-heading-l">Index Router: Home page</h1>
+    <p class="govuk-body">{{ sampleKey }}</p>
   </div>
 
 {% endblock %}

--- a/src/views/router_views/user/profile.njk
+++ b/src/views/router_views/user/profile.njk
@@ -3,8 +3,8 @@
 {% block main_content %}
 
   <div class="generic-class-name">
-    <h3>User Router: User profile page</h3>
-    <p>{{ sampleKey }}</p>
+    <h1 class="govuk-heading-l">User Router: User profile page</h1>
+    <p class="govuk-body">{{ sampleKey }}</p>
   </div>
 
 {% endblock %}

--- a/src/views/router_views/user/settings.njk
+++ b/src/views/router_views/user/settings.njk
@@ -3,8 +3,8 @@
 {% block main_content %}
 
   <div class="generic-class-name">
-    <h3>User Router: User settings page</h3>
-    <p>{{ sampleKey }}</p>
+    <h1 class="govuk-heading-l">User Router: User settings page</h1>
+    <p class="govuk-body">{{ sampleKey }}</p>
   </div>
 
 {% endblock %}


### PR DESCRIPTION
These variables are not set when generating the version on the CDN so it could cause incompatibility