### PR TITLE
Remove unnecessary styling

### DIFF
--- a/assets/src/scss/__global.scss
+++ b/assets/src/scss/__global.scss
@@ -1,21 +1,3 @@
 // See: https://frontend.design-system.service.gov.uk/sass-api-reference/
 // Import the base GOV.UK Frontend so we can make use of the utility helpers
 @import "govuk/base";
-
-html {
-  font-family: arial;
-}
-body {
-  .govuk-header__logo {
-    width: 35%;
-  }
-  .govuk-header__content {
-    width: 65%;
-  }
-}
-
-form {
-  fieldset {
-    border: 0;
-  }
-}


### PR DESCRIPTION
Having a font family of arial is not going to work because GOV.UK Frontend applies this per element.

.govuk-header__content is no longer used in the header and should not be styled anyway

form styles also should not be necessary when using GOV.UK Frontend