### PR TITLE
Ensure nodemon has access to env variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "coverage": "jest --coverage",
     "test": "jest",
     "start": "npm run build && source ./dist/config/.env && node dist/server.js",
-    "start:watch": "nodemon",
+    "start:watch": "source ./dist/config/.env && nodemon",
     "chs-dev": "nodemon --legacy-watch"
   },
   "husky": {


### PR DESCRIPTION
Nodemon is usually used with docker-chs-development which sets environment variables.
But if you want to run it outside that, they need
to be loaded in manually.