### PR TITLE
Add example titles

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -36,6 +36,7 @@ njk.addGlobal("cdnHost", process.env.CDN_HOST);
 njk.addGlobal("govukFrontendVersion", getGOVUKFrontendVersion());
 njk.addGlobal("chsUrl", process.env.CHS_URL);
 njk.addGlobal("govukRebrand", process.env.FEATURE_GOVUK_REBRAND === "true");
+njk.addGlobal("serviceName", process.env.SERVICE_NAME);
 
 // If app is behind a front-facing proxy, and to use the X-Forwarded-* headers to determine the connection and the IP address of the client
 app.enable("trust proxy");

--- a/src/config/.env.example
+++ b/src/config/.env.example
@@ -1,6 +1,7 @@
 #!bin/bash
 
 export APP_NAME=node-web-starter-ts
+export SERVICE_NAME="TypeScript Web Starter" # Used in the page title (<title>) and Service Navigation component
 export LOG_LEVEL=info
 
 export NODE_ENV=dev

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@ import app from "./app";
 // start the HTTP server
 const httpServer = http.createServer(app);
 httpServer.listen(process.env.NODE_PORT, () => {
-    console.log(`Server started at: ${process.env.NODE_HOSTNAME}:${process.env.NODE_PORT}`);
+    console.log(`Server started at: http://${process.env.NODE_HOSTNAME}:${process.env.NODE_PORT}`);
 }).on("error", err => {
     logger.error(`${err.name} - HTTP Server error: ${err.message} - ${err.stack}`);
 });
@@ -21,7 +21,7 @@ if (process.env.NODE_SSL_ENABLED === "ON") {
     const httpsServer = https.createServer(credentials, app);
 
     httpsServer.listen(process.env.NODE_PORT_SSL, () => {
-        console.log(`Secure server started at: ${process.env.NODE_HOSTNAME_SECURE}:${process.env.NODE_PORT_SSL}`);
+        console.log(`Secure server started at: https://${process.env.NODE_HOSTNAME_SECURE}:${process.env.NODE_PORT_SSL}`);
     }).on("error", err => {
         logger.error(`${err.name} - HTTPS Server error: ${err.message} - ${err.stack}`);
     });

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -5,7 +5,7 @@
 
 {% set mainContentId = "main-page-content" %}
 
-{% block pageTitle %}{{ title }}{% endblock %}
+{% block pageTitle %}{{ title }} – {{ serviceName }} – GOV.UK {% endblock %}
 
 {% block head %}
   {{ super() }}

--- a/src/views/layouts/shell.njk
+++ b/src/views/layouts/shell.njk
@@ -1,7 +1,7 @@
 {# Extends the Companies House Page Template: https://github.com/companieshouse/ch-node-utils/blob/2.0.0/docs/page-template.md #}
 {% extends "ch-node-utils/templates/layouts/template.njk" %}
 
-{% block pageTitle %}{{ title }}{% endblock %}
+{% block pageTitle %}{{ title }} – {{ serviceName }} – GOV.UK {% endblock %}
 
 {% block head %}
   {{ super() }}

--- a/src/views/partials/__header.njk
+++ b/src/views/partials/__header.njk
@@ -6,7 +6,7 @@
   homepageUrl: "https://gov.uk"
 }) }}
 {{ govukServiceNavigation({
-  serviceName: "Node.js Web Starter",
+  serviceName: serviceName,
   serviceUrl: chsUrl
 }) }}
 <div class="govuk-width-container">


### PR DESCRIPTION
Something noticed from working on how-to-verify-web they didnt have these so contributing this back.

Also adds protocols to the server boot up so we can click localhost link in the terminal.